### PR TITLE
correct Wikipedia URLs

### DIFF
--- a/data/2020/2020-06-09/science.csv
+++ b/data/2020/2020-06-09/science.csv
@@ -1,121 +1,121 @@
 name,birth,death,occupation_s,inventions_accomplishments,references,links
 "Amos, Harold",1918,2003,Microbiologist,First African-American department chair at Harvard Medical School,"6,",https://en.wikipedia.org/wiki/Harold_Amos
-"Alcorn, George Edward, Jr.",1940,NA,Physicist; inventor,Invented a method of fabricating an imaging X-ray spectrometer,"7,8,",https://en.wikipedia.org/wiki/Harold_Amos
-"Andrews, James J.",1930,1998,Mathematician,"Put forth the Andrews–Curtis conjecture in group theory with Morton L. Curtis, still unsolved","9,","https://en.wikipedia.org/wiki/George_Edward_Alcorn,_Jr."
-"Alexander, Archie",1888,1958,Civil engineer,"Responsible for the construction of many roads and bridges, including the Whitehurst Freeway, the Tidal Basin Bridge, and an extension to the Baltimore-Washington Parkway.",,https://en.wikipedia.org/wiki/James_J._Andrews_(mathematician)
-"Bailey, Leonard C.",1825,1918,Inventor,Folding bed,"10,",https://en.wikipedia.org/wiki/Archie_Alexander
-"Ball, Alice Augusta",1892,1916,Chemist,Extracted chaulmoogra oil for the treatment of Hansen's disease (leprosy),"11,",https://en.wikipedia.org/wiki/Leonard_C._Bailey
-"Banneker, Benjamin",1731,1806,Almanac author; surveyor; farmer,Constructed wooden clock; astronomer; mathematician; assisted in the survey of the original boundaries of the District of Columbia; authored a series of almanacs and ephemerides; naturalist: recorded observations on emergences of periodical cicadas and on the behavior of honey bees.,"12,",https://en.wikipedia.org/wiki/Alice_Augusta_Ball
-"Banyaga, Augustin",1947,NA,Mathematician,Work on diffeomorphisms and symplectomorphisms,"13,",https://en.wikipedia.org/wiki/Benjamin_Banneker
-"Bashen, Janet",1957,NA,Inventor; entrepreneur; professional consultant,"First African-American woman to receive a patent for a web-based software invention, LinkLine, an Equal Employment Opportunity case management and tracking software","14,",https://en.wikipedia.org/wiki/Augustin_Banyaga
-"Bath, Patricia",1942,2019,Ophthalmologist,"First African-American female physician to receive a patent for a medical invention; inventions relate to cataract surgery and include the Laserphaco Probe, which revolutionized the industry in the 1980s, and an ultrasound technique for treatment","15,16,17,",https://en.wikipedia.org/wiki/Janet_Emerson_Bashen
-"Beard, Andrew",1849,1921,Farmer; carpenter; blacksmith; railroad worker; businessman; inventor,"Janney coupler improvements; invented the car device #594,059 dated November 23, 1897; rotary engine patent #478,271 dated July 5, 1892","18,",https://en.wikipedia.org/wiki/Patricia_Bath
-"Bell, Earl S.",1977,NA,Inventor; entrepreneur; architect; industrial designer,Invented chair with sliding skin (2004) and the quantitative display apparatus (2005),"19,20,21,",https://en.wikipedia.org/wiki/Andrew_Jackson_Beard
-"Berry, Leonidas",1902,1995,Gastroenterologist,Gastroscope pioneer,"23,",https://en.wikipedia.org/wiki/Miriam_Benjamin
-"Bharucha-Reid, Albert T.",1927,1985,Mathematician; statistician,Probability theory and Markov chain theorist,"24,",https://en.wikipedia.org/wiki/Leonidas_Berry
-"Black, Keith",1957,NA,Neurosurgeon,Brain tumor surgery and research,"25,26,",https://en.wikipedia.org/wiki/Albert_Turner_Bharucha-Reid
-"Blackwell, David",1919,2010,Mathematician; statistician,"First proposed the Blackwell channel model used in coding theory and information theory; one of the eponyms of the Rao–Blackwell theorem, which is a process that significantly improves crude statistical estimators","27,",https://en.wikipedia.org/wiki/Keith_Black_(surgeon)
-"Blair, Henry",1807,1860,Inventor,Second black inventor to issue a patent; invented seed planter and cotton planter.,"28,29,",https://en.wikipedia.org/wiki/David_Blackwell
-"Boahen, Kwabena",1964,NA,Bioengineer,Silicon retina able to process images in the same manner as a living retina,"30,31,",https://en.wikipedia.org/wiki/Henry_Blair_(inventor)
-"Boone, Sarah",1832,1905,Inventor,Ironing board allowing sleeves of women's garments to be ironed more easily,"32,33,34,",https://en.wikipedia.org/wiki/Kwabena_Boahen
-"Bouchet, Edward",1852,1918,Physicist,First African-American to receive a PhD in any subject; received physics doctorate from Yale University in 1876,,https://en.wikipedia.org/wiki/Sarah_Boone
-"Bowman, James",1923,2011,Physician,Pathologist and geneticist; Professor Emeritus Pritzker School of Medicine; first tenured African-American professor at the University of Chicago Division of Biological Sciences,"35,36,",https://en.wikipedia.org/wiki/Edward_Bouchet
-"Boykin, Otis",1920,1982,Inventor; engineer,Artificial heart pacemaker control unit,"37,38,39,",https://en.wikipedia.org/wiki/James_E._Bowman
-"Brady, St. Elmo",1884,1966,Chemist,Published three scholarly abstracts in Science; collaborated on a paper published in the Journal of Industrial and Engineering Chemistry,"40,",https://en.wikipedia.org/wiki/Otis_Boykin
-"Branson, Herman",1914,1995,Physicist; educator,Protein structure research,"41,42,",https://en.wikipedia.org/wiki/St._Elmo_Brady
-"Brooks, Charles",1865,NA,Inventor[citation needed],Street sweeper truck and a type of paper punch,"43,44,",https://en.wikipedia.org/wiki/Herman_Branson
-"Brown, Marie Van Brittan",1922,1999,Inventor,Invented the home security system,"47,",https://en.wikipedia.org/w/index.php?title=Oscar_E.Brown&action=edit&redlink=1
-"Burr, John Albert",NA,NA,Inventor,Rotary-blade lawn mower patent,"48,",https://en.wikipedia.org/wiki/Marie_Van_Brittan_Brown
-"Carson, Ben",1951,NA,Pediatric neurosurgeon,Pediatric neurosurgery at Johns Hopkins University; first surgeon to successfully separate craniopagus twins,"49,",https://en.wikipedia.org/wiki/William_Warrick_Cardozo
-"Carruthers, George",1939,NA,Astrophysicist,"Invented ultraviolet camera/spectrograph, which was used by NASA when it launched Apollo 16 in 1972","47,",https://en.wikipedia.org/wiki/Ben_Carson
-"Carver, George Washington",1865,1943,Botanical researcher,"Discovered hundreds of uses for previously useless vegetables and fruits, principally the peanut","50,51,52,53,",https://en.wikipedia.org/wiki/George_Robert_Carruthers
-"Chappelle, Charles W.",1872,1941,Electrician; construction; international businessman; and aviation pioneer,"Designed long-distance flight airplane; the only African-American to invent and display the airplane at the 1911 First Industrial Air Show held in conjunction with the Auto Show at Grand Central Palace in Manhattan in New York City; president of the African Union Company, Inc.","54,55,56,",https://en.wikipedia.org/wiki/George_Washington_Carver
-"Chappelle, Emmett",1925,2019,Scientist and researcher,"Valuable contributions to several fields: medicine, biology, food science, and astrochemistry",,https://en.wikipedia.org/wiki/Charles_W._Chappelle
-"Clark, Mamie",1914,2005,Psychologist,Conducted 1940s experiments using dolls to study children's attitudes about race,,https://en.wikipedia.org/wiki/Emmett_Chappelle
+"Alcorn, George Edward, Jr.",1940,NA,Physicist; inventor,Invented a method of fabricating an imaging X-ray spectrometer,"7,8,","https://en.wikipedia.org/wiki/George_Edward_Alcorn,_Jr."
+"Andrews, James J.",1930,1998,Mathematician,"Put forth the Andrews–Curtis conjecture in group theory with Morton L. Curtis, still unsolved","9,",https://en.wikipedia.org/wiki/James_J._Andrews_(mathematician)
+"Alexander, Archie",1888,1958,Civil engineer,"Responsible for the construction of many roads and bridges, including the Whitehurst Freeway, the Tidal Basin Bridge, and an extension to the Baltimore-Washington Parkway.",NA,https://en.wikipedia.org/wiki/Archie_Alexander
+"Bailey, Leonard C.",1825,1918,Inventor,Folding bed,"10,",https://en.wikipedia.org/wiki/Leonard_C._Bailey
+"Ball, Alice Augusta",1892,1916,Chemist,Extracted chaulmoogra oil for the treatment of Hansen's disease (leprosy),"11,",https://en.wikipedia.org/wiki/Alice_Augusta_Ball
+"Banneker, Benjamin",1731,1806,Almanac author; surveyor; farmer,Constructed wooden clock; astronomer; mathematician; assisted in the survey of the original boundaries of the District of Columbia; authored a series of almanacs and ephemerides; naturalist: recorded observations on emergences of periodical cicadas and on the behavior of honey bees.,"12,",https://en.wikipedia.org/wiki/Benjamin_Banneker
+"Banyaga, Augustin",1947,NA,Mathematician,Work on diffeomorphisms and symplectomorphisms,"13,",https://en.wikipedia.org/wiki/Augustin_Banyaga
+"Bashen, Janet",1957,NA,Inventor; entrepreneur; professional consultant,"First African-American woman to receive a patent for a web-based software invention, LinkLine, an Equal Employment Opportunity case management and tracking software","14,",https://en.wikipedia.org/wiki/Janet_Emerson_Bashen
+"Bath, Patricia",1942,2019,Ophthalmologist,"First African-American female physician to receive a patent for a medical invention; inventions relate to cataract surgery and include the Laserphaco Probe, which revolutionized the industry in the 1980s, and an ultrasound technique for treatment","15,16,17,",https://en.wikipedia.org/wiki/Patricia_Bath
+"Beard, Andrew",1849,1921,Farmer; carpenter; blacksmith; railroad worker; businessman; inventor,"Janney coupler improvements; invented the car device #594,059 dated November 23, 1897; rotary engine patent #478,271 dated July 5, 1892","18,",https://en.wikipedia.org/wiki/Andrew_Jackson_Beard
+"Bell, Earl S.",1977,NA,Inventor; entrepreneur; architect; industrial designer,Invented chair with sliding skin (2004) and the quantitative display apparatus (2005),"19,20,21,",https://en.wikipedia.org/wiki/Miriam_Benjamin
+"Berry, Leonidas",1902,1995,Gastroenterologist,Gastroscope pioneer,"23,",https://en.wikipedia.org/wiki/Leonidas_Berry
+"Bharucha-Reid, Albert T.",1927,1985,Mathematician; statistician,Probability theory and Markov chain theorist,"24,",https://en.wikipedia.org/wiki/Albert_Turner_Bharucha-Reid
+"Black, Keith",1957,NA,Neurosurgeon,Brain tumor surgery and research,"25,26,",https://en.wikipedia.org/wiki/Keith_Black_(surgeon)
+"Blackwell, David",1919,2010,Mathematician; statistician,"First proposed the Blackwell channel model used in coding theory and information theory; one of the eponyms of the Rao–Blackwell theorem, which is a process that significantly improves crude statistical estimators","27,",https://en.wikipedia.org/wiki/David_Blackwell
+"Blair, Henry",1807,1860,Inventor,Second black inventor to issue a patent; invented seed planter and cotton planter.,"28,29,",https://en.wikipedia.org/wiki/Henry_Blair_(inventor)
+"Boahen, Kwabena",1964,NA,Bioengineer,Silicon retina able to process images in the same manner as a living retina,"30,31,",https://en.wikipedia.org/wiki/Kwabena_Boahen
+"Boone, Sarah",1832,1905,Inventor,Ironing board allowing sleeves of women's garments to be ironed more easily,"32,33,34,",https://en.wikipedia.org/wiki/Sarah_Boone
+"Bouchet, Edward",1852,1918,Physicist,First African-American to receive a PhD in any subject; received physics doctorate from Yale University in 1876,NA,https://en.wikipedia.org/wiki/Edward_Bouchet
+"Bowman, James",1923,2011,Physician,Pathologist and geneticist; Professor Emeritus Pritzker School of Medicine; first tenured African-American professor at the University of Chicago Division of Biological Sciences,"35,36,",https://en.wikipedia.org/wiki/James_E._Bowman
+"Boykin, Otis",1920,1982,Inventor; engineer,Artificial heart pacemaker control unit,"37,38,39,",https://en.wikipedia.org/wiki/Otis_Boykin
+"Brady, St. Elmo",1884,1966,Chemist,Published three scholarly abstracts in Science; collaborated on a paper published in the Journal of Industrial and Engineering Chemistry,"40,",https://en.wikipedia.org/wiki/St._Elmo_Brady
+"Branson, Herman",1914,1995,Physicist; educator,Protein structure research,"41,42,",https://en.wikipedia.org/wiki/Herman_Branson
+"Brooks, Charles",1865,NA,Inventor[citation needed],Street sweeper truck and a type of paper punch,"43,44,",https://en.wikipedia.org/w/index.php?title=Oscar_E.Brown&action=edit&redlink=1
+"Brown, Marie Van Brittan",1922,1999,Inventor,Invented the home security system,"47,",https://en.wikipedia.org/wiki/Marie_Van_Brittan_Brown
+"Burr, John Albert",NA,NA,Inventor,Rotary-blade lawn mower patent,"48,",https://en.wikipedia.org/wiki/William_Warrick_Cardozo
+"Carson, Ben",1951,NA,Pediatric neurosurgeon,Pediatric neurosurgery at Johns Hopkins University; first surgeon to successfully separate craniopagus twins,"49,",https://en.wikipedia.org/wiki/Ben_Carson
+"Carruthers, George",1939,NA,Astrophysicist,"Invented ultraviolet camera/spectrograph, which was used by NASA when it launched Apollo 16 in 1972","47,",https://en.wikipedia.org/wiki/George_Robert_Carruthers
+"Carver, George Washington",1865,1943,Botanical researcher,"Discovered hundreds of uses for previously useless vegetables and fruits, principally the peanut","50,51,52,53,",https://en.wikipedia.org/wiki/George_Washington_Carver
+"Chappelle, Charles W.",1872,1941,Electrician; construction; international businessman; and aviation pioneer,"Designed long-distance flight airplane; the only African-American to invent and display the airplane at the 1911 First Industrial Air Show held in conjunction with the Auto Show at Grand Central Palace in Manhattan in New York City; president of the African Union Company, Inc.","54,55,56,",https://en.wikipedia.org/wiki/Charles_W._Chappelle
+"Chappelle, Emmett",1925,2019,Scientist and researcher,"Valuable contributions to several fields: medicine, biology, food science, and astrochemistry",NA,https://en.wikipedia.org/wiki/Emmett_Chappelle
+"Clark, Mamie",1914,2005,Psychologist,Conducted 1940s experiments using dolls to study children's attitudes about race,NA,https://en.wikipedia.org/wiki/Kenneth_and_Mamie_Clark
 "Clark, Kenneth",1917,1983,Psychologist,First Black president of the American Psychological Association,"57,",https://en.wikipedia.org/wiki/Kenneth_and_Mamie_Clark
-"Crosthwait, David, Jr.",1898,1976,Research engineer,"Heating, ventilation, and air conditioning; received some 40 US patents relating to HVAC systems",,https://en.wikipedia.org/wiki/Kenneth_and_Mamie_Clark
-"Curtis, James H (Nick)",1935,NA,Researcher; chemist (electronics/specialty chemicals),"Organic ionogen for aluminum electrolytic capacitors, cationic dialdehyde polysaccharides for wet strength paper and others, US Patent Office US Pat #3609467 US Pat #3547423 and others",,https://en.wikipedia.org/wiki/David_Crosthwait
-"Dabiri, John",1980,NA,Biophysicist,Expert on jellyfish hydrodynamics and designer of a vertical-axis wind farm adapted from schooling fish,,https://en.wikipedia.org/w/index.php?title=Nick_Curtis&action=edit&redlink=1
-"Daly, Marie Maynard",1921,2003,Chemist,First black American woman with a PhD in chemistry,,https://en.wikipedia.org/wiki/John_Dabiri
-"Dean, Mark",1957,NA,Computer scientist,"Led the team that developed the ISA bus, and led the design team responsible for creating the first one-gigahertz computer processor chip","58,59,60,",https://en.wikipedia.org/wiki/Marie_Maynard_Daly
-"Drew, Charles",1904,1950,Medical researcher,Developed improved techniques for blood storage,,https://en.wikipedia.org/wiki/Mark_Dean_(computer_scientist)
-"Du Chaillu, Paul",1831,1903,ZoologistexplorerAnthropologist,"Explorer; first modern European outsider to confirm the existence of gorillas, and later the Pygmy people of central Africa; identified as white throughout life, but his mother was a Réunionnais mulatto; settled in America and considered it his country by adoption; the full aspects of his ancestry were not uncovered until 1979, and are still little known today",,https://en.wikipedia.org/wiki/Charles_R._Drew
-"Easley, Annie",1933,NA,Computer scientist,"Work at the Lewis Research Center of the National Aeronautics and Space Administration and its predecessor, the National Advisory Committee for Aeronautics","61,62,",https://en.wikipedia.org/wiki/Paul_Du_Chaillu
-"Ellis, Clarence ""Skip""",1943,2014,Computer scientist,First African American with a PhD in computer science; software inventor including OfficeTalk at Xerox PARC,"63,64,",https://en.wikipedia.org/wiki/Annie_Easley
-"Ezerioha, Bisi",1972,NA,Automotive engineer,Drag racing engineer and driver,,https://en.wikipedia.org/wiki/Clarence_Ellis_(computer_scientist)
-"Ferguson, Lloyd Noel",1918,2011,Chemist; educator,"Chemistry doctorate, first received (1943, University of California, Berkeley)","65,66,67,",https://en.wikipedia.org/wiki/Bisi_Ezerioha
-"Fryer, Roland G., Jr.",1977,NA,Economist; social scientist; statistician,Inequality studies,,https://en.wikipedia.org/wiki/Lloyd_Noel_Ferguson
-"Gates, Sylvester James",1950,NA,Theoretical physicist,"Work on supersymmetry, supergravity, and superstring theory","68,69,","https://en.wikipedia.org/wiki/Roland_G._Fryer,_Jr."
-"Goode, Sarah E.",1855,1905,Inventor,Cabinet bed invention; first African-American woman to receive a patent in the United States,"70,71,",https://en.wikipedia.org/wiki/Sylvester_James_Gates
-"Gilbert, Juan E.",1969,NA,Computer scientist,Awarded the first Presidential Endowed Chair at Clemson University in honor of his accomplishments,,https://en.wikipedia.org/wiki/Sarah_E._Goode
-"Grant, George F.",1846,1910,Dentist; professor,"The first African-American professor at Harvard, Boston dentist, and inventor of a wooden golf tee.","72,",https://en.wikipedia.org/wiki/Juan_E._Gilbert
-"Graves, Joseph L.",1955,NA,Evolutionary biologist,,"73,74,75,",https://en.wikipedia.org/wiki/George_Franklin_Grant
-"Green, Lisa",NA,NA,Linguist,Specializes in syntax and the study of African American English,,https://en.wikipedia.org/wiki/Joseph_L._Graves
-"Greenaugh, Kevin",1956,NA,Nuclear engineer,,"76,",https://en.wikipedia.org/wiki/Lisa_Green_(linguist)
-"Griffin, Bessie Blount",1914,2009,Physical therapist; inventor,Amputee self-feeding device,"77,78,",https://en.wikipedia.org/wiki/Kevin_Greenaugh
-"Hall, Lloyd",1894,1971,Chemist,,,https://en.wikipedia.org/wiki/Bessie_Blount_Griffin
-"Harris, James A.",1932,2000,,Co-discovered Rutherfordium (element 104) and Dubnium (element 105) at Lawrence Livermore Laboratory,"79,",https://en.wikipedia.org/wiki/Lloyd_Hall
-"Hawkins, Walter Lincoln",1911,1992,Scientist,Inventor at Bell Laboratories,"80,",https://en.wikipedia.org/wiki/James_Andrew_Harris
-"Hodge, John E.",1914,1996,Chemist,,,https://en.wikipedia.org/wiki/Walter_Lincoln_Hawkins
-"Holley, Kerrie",1954,NA,Computer scientist,IBM's 1st black Distinguished Engineer and 2nd black IBM Fellow.  Inventor of several software engineering techniques including system and methods for locating mobile devices using location and presence information,"81,",https://en.wikipedia.org/wiki/John_E._Hodge
-"Jackson, John W",1953,2007,Electrical Engineer; inventor,Co-inventor of imaging x-ray spectrometer.,,https://en.wikipedia.org/wiki/Kerrie_Holley
-"Jackson, Dr. Shirley",1946,NA,Physicist,"Helped develop technologies leading to the invention of the touch-tone telephone, portable fax, solar cells, fiber optic cables, and the technology enabling caller ID and call waiting.[citation needed] However, in a recent article from MIT, there is no evidence that she helped to develop these technologies.[82]","47,83,",https://en.wikipedia.org/wiki/Mary_Jackson_(engineer)
-"Jarvis, Erich",1965,NA,Neurobiologist,Duke University neuroscience bird songs studies,"84,85,86,",https://en.wikipedia.org/wiki/Shirley_Ann_Jackson
-"Jennings, Thomas L.",1791,1856,Inventor,First African American to be granted a patent (for a dry cleaning process called dry scouring),"87,",https://en.wikipedia.org/wiki/Erich_Jarvis
-"Johnson, Isaac",NA,NA,Inventor,"Held patent for improvements to the bicycle frame, specifically so it could be taken apart for compact storage","88,",https://en.wikipedia.org/wiki/Thomas_L._Jennings
-"Isola, Oluwabusuyi",1965,NA,Professor; International Finance; inventor,Invented Double Sided Guitar,,https://en.wikipedia.org/wiki/Lonnie_Johnson_(inventor)
-"Jones, Frederick McKinley",1893,1961,Inventor,Invented refrigerated truck systems,"92,",https://en.wikipedia.org/wiki/Katherine_Johnson
-"Julian, Percy",1899,1975,Chemist,First to synthesize the natural product physostigmine; earned 130 chemical patents; lauded for humanitarian achievements,"93,94,95,96,",https://en.wikipedia.org/wiki/Frederick_McKinley_Jones
-"Just, Ernest",1883,1941,Woods Hole Marine Biology Institute biologist,Provided basic and initial descriptions of the structure–function–property relationship of the plasma membrane of biological cells,"97,98,99,",https://en.wikipedia.org/wiki/Percy_Lavon_Julian
-"Kittles, Rick",1967,NA,Geneticist,Work in tracing the ancestry of African Americans via DNA testing,"100,101,",https://en.wikipedia.org/wiki/Ernest_Everett_Just
-"Kountz, Samuel L.",1930,1981,Transplant surgeon; researcher,"Organ transplantation pioneer, particularly renal transplant research and surgery; author or co-author of 172 articles in scientific publications","102,103,104,105,",https://en.wikipedia.org/wiki/Rick_Kittles
-"Latimer, Lewis",1848,1928,Inventor; draftsman; expert witness,Worked as a draftsman for both Alexander Graham Bell and Thomas Edison; became a member of Edison's Pioneers and served as an expert witness in many light bulb litigation lawsuits; said to have invented the water closet,"106,107,108,109,",https://en.wikipedia.org/wiki/Samuel_L._Kountz
-"Lawson, Jerry",1940,2011,Computer engineer,"Designer of Fairchild Channel F, the first programmable ROM cartridge-based video game console","110,111,",https://en.wikipedia.org/wiki/Lewis_Howard_Latimer
-"Lee, Raphael Carl",1949,NA,Surgeon; biomedical engineer[citation needed],"Paul and Aileen Russell Professor, Pritzker School of Medicine; MacArthur Fellow, Searle Scholar, founder and chairman, Avocet Polymer Technologies, Inc.; founder and chairman, Renacyte BioMolecular Technologies, Inc; discovered use of surfactant copolymers as molecular chaperones to augment endogenous injury repair mechanisms of living cells; holder of many patents covering scar treatment therapies, tissue engineered ligaments, brain trauma therapies, and protective garments[citation needed]","citation needed,",https://en.wikipedia.org/wiki/Jerry_Lawson_(engineer)
-"Lynk, Beebe Steven",1872,1948,Chemist,Teacher at West Tennessee University,,https://en.wikipedia.org/wiki/Raphael_Carl_Lee
-"Mahoney, Mary",1845,1926,Nurse,First African American to study and work as a professionally trained nurse in the United States[112],,https://en.wikipedia.org/wiki/Beebe_Steven_Lynk
-"Matzeliger, Jan",1852,1889,Inventor,Shoe assembly Machine,"113,114,",https://en.wikipedia.org/wiki/Mary_Eliza_Mahoney
-"McBay, Henry",1914,1995,Chemist,His discoveries allowed chemists around the world to create inexpensive peroxide compounds,"115,116,",https://en.wikipedia.org/wiki/Jan_Ernst_Matzeliger
-"McCoy, Elijah",1844,1929,Inventor,"Invented a version of the automatic lubricator for steam engines, McCoy learned a great deal of his skills from a mechanical apprenticeship when he was age fifteen  .","117,118,",https://en.wikipedia.org/wiki/Henry_Cecil_McBay
-"McLurkin, James",1972,NA,Roboticist,,"119,",https://en.wikipedia.org/wiki/Elijah_McCoy
-"McWhorter, John",1965,NA,Linguist,Specializes in the study of creole language formation,,https://en.wikipedia.org/wiki/James_McLurkin
-"Montgomery, Benjamin",1819,1877,Inventor,Designed a steam operated propeller to provide propulsion to boats in shallow water,,https://en.wikipedia.org/wiki/John_McWhorter
-"Moore, Willie Hobbs",1934,1994,Physicist,First African American woman to earn a PhD in Physics (University of Michigan Ann Arbor 1972) on vibrational analysis of secondary chlorides,"120,",https://en.wikipedia.org/wiki/Ben_Montgomery
-"Morgan, Garrett",1877,1963,Inventor,"Invented an early version of a gas mask called a smoke hood, and created the first traffic light that included a third ""warning"" position which is standard today. Morgan also developed a chemical that was used in hair products for hair-straightening.","121,122,",https://en.wikipedia.org/wiki/Willie_Hobbs_Moore
-"Mensah, Thomas",NA,NA,Inventor,,,https://en.wikipedia.org/wiki/Garrett_Morgan
-"Miles, Alexander",1838,1918,Inventor,Invented electric elevator doors that automatically open and close,"123,",https://en.wikipedia.org/wiki/Thomas_Mensah_(engineer)
-"Nriagu, Jerome",1944,NA,Geochemist,Studies toxic metals in the environment; supporter of the lead poisoning thesis of the decline of the Roman Empire,,https://en.wikipedia.org/wiki/Alexander_Miles
-"Ogbu, John Uzo",1939,2003,Anthropologist,Ethnic studies in education and economics,"124,125,",https://en.wikipedia.org/wiki/Jerome_Nriagu
-"Olukotun, Kunle",NA,NA,Computer scientist,Early advocate and researcher of multi-core processors,,https://en.wikipedia.org/wiki/John_Ogbu
-"Oyekan, Soni",1946,NA,Chemical engineer,Inventions in oil refining,,https://en.wikipedia.org/wiki/Kunle_Olukotun
-"Parker, Alice H.",1895,NA,Inventor,Furnace for Central Heating,,https://en.wikipedia.org/wiki/Soni_Oyekan
-"Poindexter, Hildrus",1901,1987,Bacteriologist; epidemiologist,"Work on the epidemiology of tropical diseases, including malaria",,https://en.wikipedia.org/wiki/Alice_H._Parker
-"Petters, Arlie",1964,NA,Physicist,Work on the mathematical physics of gravitational lensing,,https://en.wikipedia.org/wiki/Hildrus_Poindexter
-"Quarterman, Lloyd Albert",1918,1982,Scientist; fluoride chemist,"Manhattan Project, worked with Albert Einstein and Enrico Fermi",,https://en.wikipedia.org/wiki/Arlie_Petters
-"Renfroe, Earl",1907,2000,Orthodontist,,"126,127,",https://en.wikipedia.org/wiki/Lloyd_Quarterman
-"Rillieux, Norbert",1806,1894,Engineer; inventor,Inventor of the multiple-effect evaporator,"128,",https://en.wikipedia.org/wiki/Earl_W._Renfroe
-"Robinson, Larry",1957,NA,Environmental chemist,Investigated possible role of arsenic in the death of Zachary Taylor; interim president of Florida A&M University,,https://en.wikipedia.org/wiki/Norbert_Rillieux
-"Ross, Archia",NA,NA,Inventor,"A runner for stoops (1896), bag closure device (1898), a wrinkle-preventing trouser stretcher (1899), a garment-hanger (1903), and a holder for brooms and like articles.","129,130,131,132,133,",https://en.wikipedia.org/wiki/Larry_Robinson_(chemist)
-"Russell, Jesse",1948,NA,Engineer; inventor,Wireless communications engineer,,https://en.wikipedia.org/wiki/Archia_Ross
-"Sammons, Walter",1890,1973,Inventor,Patent for hot comb,"134,",https://en.wikipedia.org/wiki/Jesse_Russell
-"Steele, Claude",1946,NA,Psychologist; social scientist,Stereotype threat studies,,https://en.wikipedia.org/wiki/Thomas_Sowell
-"Stiff, Lee",1941,NA,Mathematician,President of the National Council of Teachers of Mathematics from 2000 to 2002,"139,",https://en.wikipedia.org/wiki/Claude_Steele
-"Snyder, Window",1976,NA,Computer engineer,"Security engineer at Microsoft, Mozilla, and Apple",,https://en.wikipedia.org/wiki/Lee_Stiff
-"Temple, Lewis",1800,1854,Inventor; blacksmith; abolitionist,Inventor of the toggling whaling harpoon head,"140,",https://en.wikipedia.org/wiki/Window_Snyder
-"Thomas, Vivien",1910,1985,Surgical technician,Blue baby syndrome treatment in the 1940s,"141,142,143,",https://en.wikipedia.org/wiki/Lewis_Temple
-"Turner, Charles Henry",1867,1923,Zoologist,"First person to prove that insects can hear and can distinguish pitch, that cockroaches can learn by trial and error, and that honeybees can see color; first African-American to receive a PhD from the University of Chicago","144,",https://en.wikipedia.org/wiki/Vivien_Thomas
-"Tyree, G. Bernadette",NA,NA,Biochemist[citation needed],"Program Director, Division of Musculoskeletal Diseases, at National Institute of Arthritis and Musculoskeletal and Skin Diseases, National Institutes of Health","145,",https://en.wikipedia.org/wiki/Charles_Henry_Turner_(zoologist)
-"Vaughan, Dorothy",1910,2008,Mathematician,Worked for NACA and NASA at Langley Research Center,,https://en.wikipedia.org/wiki/Neil_deGrasse_Tyson
-"Valerino, Powtawche",1980,NA,Engineer,Worked for JPL and NASA at Langley Research Center,,https://en.wikipedia.org/wiki/Dorothy_Vaughan
-"Walker, Arthur B. C., Jr.",1936,2001,Astronomer,Developed normal incidence multilayer XUV telescopes to photograph the solar corona,"149,150,151,",https://en.wikipedia.org/wiki/Powtawche_Valerino
-"Walker, C. J.",1867,1919,Inventor,Created black cosmetic products,"152,","https://en.wikipedia.org/wiki/Arthur_B._C._Walker,_Jr."
-"Washington, Warren M.",1936,NA,Atmospheric scientist,Former chair of the National Science Board,"153,154,155,156,",https://en.wikipedia.org/wiki/Madam_C._J._Walker
-"West, James E.",1931,NA,Acoustician; inventor,Co-developed the foil electret microphone,"157,158,159,",https://en.wikipedia.org/wiki/Warren_M._Washington
-"Wilkins, J. Ernest, Jr.",1923,2011,Mathematician; engineer; nuclear scientist,Entered University of Chicago at age 13; PhD at 19; worked on the Manhattan Project; wrote over 100 scientific papers; helped recruit minorities into the sciences,"160,161,162,",https://en.wikipedia.org/wiki/James_Edward_Maceo_West
-"Williams, Daniel",1856,1931,Surgeon,The first black person on record to have successfully performed pericardium (the sac surrounding the heart) surgery to repair a wound.,"163,circular reference,","https://en.wikipedia.org/wiki/J._Ernest_Wilkins,_Jr."
-"Williams, Scott W.",1943,NA,Mathematician,,,https://en.wikipedia.org/wiki/Daniel_Hale_Williams
-"Williams, Walter E.",1936,NA,Economist; social scientist,,"164,165,166,",https://en.wikipedia.org/wiki/Scott_W._Williams
-"Woods, Granville",1856,1910,Inventor,Invented the synchronous multiplex railway telegraph,"167,",https://en.wikipedia.org/wiki/Walter_E._Williams
-"Wright, Jane C.",1919,2013,Cancer research and surgeon,Noted for her contributions to chemotherapy and for pioneering the use of the drug methotrexate to treat breast cancer and skin cancer,,https://en.wikipedia.org/wiki/Granville_Woods
-"Wright, Louis T.",1891,1952,Surgeon,Led team that first used Aureomycin as a treatment on humans,"168,169,170,",https://en.wikipedia.org/wiki/Jane_C._Wright
-"Young, Roger Arliner",1899,1964,Zoologist,First African-American woman to receive a doctorate degree in zoology,"171,172,",https://en.wikipedia.org/wiki/Louis_T._Wright
+"Crosthwait, David, Jr.",1898,1976,Research engineer,"Heating, ventilation, and air conditioning; received some 40 US patents relating to HVAC systems",NA,https://en.wikipedia.org/wiki/David_Crosthwait
+"Curtis, James H (Nick)",1935,NA,Researcher; chemist (electronics/specialty chemicals),"Organic ionogen for aluminum electrolytic capacitors, cationic dialdehyde polysaccharides for wet strength paper and others, US Patent Office US Pat #3609467 US Pat #3547423 and others",NA,https://en.wikipedia.org/w/index.php?title=Nick_Curtis&action=edit&redlink=1
+"Dabiri, John",1980,NA,Biophysicist,Expert on jellyfish hydrodynamics and designer of a vertical-axis wind farm adapted from schooling fish,NA,https://en.wikipedia.org/wiki/John_Dabiri
+"Daly, Marie Maynard",1921,2003,Chemist,First black American woman with a PhD in chemistry,NA,https://en.wikipedia.org/wiki/Marie_Maynard_Daly
+"Dean, Mark",1957,NA,Computer scientist,"Led the team that developed the ISA bus, and led the design team responsible for creating the first one-gigahertz computer processor chip","58,59,60,",https://en.wikipedia.org/wiki/Mark_Dean_(computer_scientist)
+"Drew, Charles",1904,1950,Medical researcher,Developed improved techniques for blood storage,NA,https://en.wikipedia.org/wiki/Charles_R._Drew
+"Du Chaillu, Paul",1831,1903,ZoologistexplorerAnthropologist,"Explorer; first modern European outsider to confirm the existence of gorillas, and later the Pygmy people of central Africa; identified as white throughout life, but his mother was a Réunionnais mulatto; settled in America and considered it his country by adoption; the full aspects of his ancestry were not uncovered until 1979, and are still little known today",NA,https://en.wikipedia.org/wiki/Paul_Du_Chaillu
+"Easley, Annie",1933,NA,Computer scientist,"Work at the Lewis Research Center of the National Aeronautics and Space Administration and its predecessor, the National Advisory Committee for Aeronautics","61,62,",https://en.wikipedia.org/wiki/Annie_Easley
+"Ellis, Clarence ""Skip""",1943,2014,Computer scientist,First African American with a PhD in computer science; software inventor including OfficeTalk at Xerox PARC,"63,64,",https://en.wikipedia.org/wiki/Clarence_Ellis_(computer_scientist)
+"Ezerioha, Bisi",1972,NA,Automotive engineer,Drag racing engineer and driver,NA,https://en.wikipedia.org/wiki/Bisi_Ezerioha
+"Ferguson, Lloyd Noel",1918,2011,Chemist; educator,"Chemistry doctorate, first received (1943, University of California, Berkeley)","65,66,67,",https://en.wikipedia.org/wiki/Lloyd_Noel_Ferguson
+"Fryer, Roland G., Jr.",1977,NA,Economist; social scientist; statistician,Inequality studies,NA,"https://en.wikipedia.org/wiki/Roland_G._Fryer,_Jr."
+"Gates, Sylvester James",1950,NA,Theoretical physicist,"Work on supersymmetry, supergravity, and superstring theory","68,69,",https://en.wikipedia.org/wiki/Sylvester_James_Gates
+"Goode, Sarah E.",1855,1905,Inventor,Cabinet bed invention; first African-American woman to receive a patent in the United States,"70,71,",https://en.wikipedia.org/wiki/Sarah_E._Goode
+"Gilbert, Juan E.",1969,NA,Computer scientist,Awarded the first Presidential Endowed Chair at Clemson University in honor of his accomplishments,NA,https://en.wikipedia.org/wiki/Juan_E._Gilbert
+"Grant, George F.",1846,1910,Dentist; professor,"The first African-American professor at Harvard, Boston dentist, and inventor of a wooden golf tee.","72,",https://en.wikipedia.org/wiki/George_Franklin_Grant
+"Graves, Joseph L.",1955,NA,Evolutionary biologist,NA,"73,74,75,",https://en.wikipedia.org/wiki/Joseph_L._Graves
+"Green, Lisa",NA,NA,Linguist,Specializes in syntax and the study of African American English,NA,https://en.wikipedia.org/wiki/Lisa_Green_(linguist)
+"Greenaugh, Kevin",1956,NA,Nuclear engineer,NA,"76,",https://en.wikipedia.org/wiki/Kevin_Greenaugh
+"Griffin, Bessie Blount",1914,2009,Physical therapist; inventor,Amputee self-feeding device,"77,78,",https://en.wikipedia.org/wiki/Bessie_Blount_Griffin
+"Hall, Lloyd",1894,1971,Chemist,NA,NA,https://en.wikipedia.org/wiki/Lloyd_Hall
+"Harris, James A.",1932,2000,NA,Co-discovered Rutherfordium (element 104) and Dubnium (element 105) at Lawrence Livermore Laboratory,"79,",https://en.wikipedia.org/wiki/James_Andrew_Harris
+"Hawkins, Walter Lincoln",1911,1992,Scientist,Inventor at Bell Laboratories,"80,",https://en.wikipedia.org/wiki/Walter_Lincoln_Hawkins
+"Hodge, John E.",1914,1996,Chemist,NA,NA,https://en.wikipedia.org/wiki/John_E._Hodge
+"Holley, Kerrie",1954,NA,Computer scientist,IBM's 1st black Distinguished Engineer and 2nd black IBM Fellow.  Inventor of several software engineering techniques including system and methods for locating mobile devices using location and presence information,"81,",https://en.wikipedia.org/wiki/Kerrie_Holley
+"Jackson, John W",1953,2007,Electrical Engineer; inventor,Co-inventor of imaging x-ray spectrometer.,NA,https://en.wikipedia.org/wiki/Mary_Jackson_(engineer)
+"Jackson, Dr. Shirley",1946,NA,Physicist,"Helped develop technologies leading to the invention of the touch-tone telephone, portable fax, solar cells, fiber optic cables, and the technology enabling caller ID and call waiting.[citation needed] However, in a recent article from MIT, there is no evidence that she helped to develop these technologies.[82]","47,83,",https://en.wikipedia.org/wiki/Shirley_Ann_Jackson
+"Jarvis, Erich",1965,NA,Neurobiologist,Duke University neuroscience bird songs studies,"84,85,86,",https://en.wikipedia.org/wiki/Erich_Jarvis
+"Jennings, Thomas L.",1791,1856,Inventor,First African American to be granted a patent (for a dry cleaning process called dry scouring),"87,",https://en.wikipedia.org/wiki/Thomas_L._Jennings
+"Johnson, Isaac",NA,NA,Inventor,"Held patent for improvements to the bicycle frame, specifically so it could be taken apart for compact storage","88,",https://en.wikipedia.org/wiki/Lonnie_Johnson_(inventor)
+"Isola, Oluwabusuyi",1965,NA,Professor; International Finance; inventor,Invented Double Sided Guitar,NA,https://en.wikipedia.org/wiki/Katherine_Johnson
+"Jones, Frederick McKinley",1893,1961,Inventor,Invented refrigerated truck systems,"92,",https://en.wikipedia.org/wiki/Frederick_McKinley_Jones
+"Julian, Percy",1899,1975,Chemist,First to synthesize the natural product physostigmine; earned 130 chemical patents; lauded for humanitarian achievements,"93,94,95,96,",https://en.wikipedia.org/wiki/Percy_Lavon_Julian
+"Just, Ernest",1883,1941,Woods Hole Marine Biology Institute biologist,Provided basic and initial descriptions of the structure–function–property relationship of the plasma membrane of biological cells,"97,98,99,",https://en.wikipedia.org/wiki/Ernest_Everett_Just
+"Kittles, Rick",1967,NA,Geneticist,Work in tracing the ancestry of African Americans via DNA testing,"100,101,",https://en.wikipedia.org/wiki/Rick_Kittles
+"Kountz, Samuel L.",1930,1981,Transplant surgeon; researcher,"Organ transplantation pioneer, particularly renal transplant research and surgery; author or co-author of 172 articles in scientific publications","102,103,104,105,",https://en.wikipedia.org/wiki/Samuel_L._Kountz
+"Latimer, Lewis",1848,1928,Inventor; draftsman; expert witness,Worked as a draftsman for both Alexander Graham Bell and Thomas Edison; became a member of Edison's Pioneers and served as an expert witness in many light bulb litigation lawsuits; said to have invented the water closet,"106,107,108,109,",https://en.wikipedia.org/wiki/Lewis_Howard_Latimer
+"Lawson, Jerry",1940,2011,Computer engineer,"Designer of Fairchild Channel F, the first programmable ROM cartridge-based video game console","110,111,",https://en.wikipedia.org/wiki/Jerry_Lawson_(engineer)
+"Lee, Raphael Carl",1949,NA,Surgeon; biomedical engineer[citation needed],"Paul and Aileen Russell Professor, Pritzker School of Medicine; MacArthur Fellow, Searle Scholar, founder and chairman, Avocet Polymer Technologies, Inc.; founder and chairman, Renacyte BioMolecular Technologies, Inc; discovered use of surfactant copolymers as molecular chaperones to augment endogenous injury repair mechanisms of living cells; holder of many patents covering scar treatment therapies, tissue engineered ligaments, brain trauma therapies, and protective garments[citation needed]","citation needed,",https://en.wikipedia.org/wiki/Raphael_Carl_Lee
+"Lynk, Beebe Steven",1872,1948,Chemist,Teacher at West Tennessee University,NA,https://en.wikipedia.org/wiki/Beebe_Steven_Lynk
+"Mahoney, Mary",1845,1926,Nurse,First African American to study and work as a professionally trained nurse in the United States[112],NA,https://en.wikipedia.org/wiki/Mary_Eliza_Mahoney
+"Matzeliger, Jan",1852,1889,Inventor,Shoe assembly Machine,"113,114,",https://en.wikipedia.org/wiki/Jan_Ernst_Matzeliger
+"McBay, Henry",1914,1995,Chemist,His discoveries allowed chemists around the world to create inexpensive peroxide compounds,"115,116,",https://en.wikipedia.org/wiki/Henry_Cecil_McBay
+"McCoy, Elijah",1844,1929,Inventor,"Invented a version of the automatic lubricator for steam engines, McCoy learned a great deal of his skills from a mechanical apprenticeship when he was age fifteen  .","117,118,",https://en.wikipedia.org/wiki/Elijah_McCoy
+"McLurkin, James",1972,NA,Roboticist,NA,"119,",https://en.wikipedia.org/wiki/James_McLurkin
+"McWhorter, John",1965,NA,Linguist,Specializes in the study of creole language formation,NA,https://en.wikipedia.org/wiki/John_McWhorter
+"Montgomery, Benjamin",1819,1877,Inventor,Designed a steam operated propeller to provide propulsion to boats in shallow water,NA,https://en.wikipedia.org/wiki/Ben_Montgomery
+"Moore, Willie Hobbs",1934,1994,Physicist,First African American woman to earn a PhD in Physics (University of Michigan Ann Arbor 1972) on vibrational analysis of secondary chlorides,"120,",https://en.wikipedia.org/wiki/Willie_Hobbs_Moore
+"Morgan, Garrett",1877,1963,Inventor,"Invented an early version of a gas mask called a smoke hood, and created the first traffic light that included a third ""warning"" position which is standard today. Morgan also developed a chemical that was used in hair products for hair-straightening.","121,122,",https://en.wikipedia.org/wiki/Garrett_Morgan
+"Mensah, Thomas",NA,NA,Inventor,NA,NA,https://en.wikipedia.org/wiki/Thomas_Mensah_(engineer)
+"Miles, Alexander",1838,1918,Inventor,Invented electric elevator doors that automatically open and close,"123,",https://en.wikipedia.org/wiki/Alexander_Miles
+"Nriagu, Jerome",1944,NA,Geochemist,Studies toxic metals in the environment; supporter of the lead poisoning thesis of the decline of the Roman Empire,NA,https://en.wikipedia.org/wiki/Jerome_Nriagu
+"Ogbu, John Uzo",1939,2003,Anthropologist,Ethnic studies in education and economics,"124,125,",https://en.wikipedia.org/wiki/John_Ogbu
+"Olukotun, Kunle",NA,NA,Computer scientist,Early advocate and researcher of multi-core processors,NA,https://en.wikipedia.org/wiki/Kunle_Olukotun
+"Oyekan, Soni",1946,NA,Chemical engineer,Inventions in oil refining,NA,https://en.wikipedia.org/wiki/Soni_Oyekan
+"Parker, Alice H.",1895,NA,Inventor,Furnace for Central Heating,NA,https://en.wikipedia.org/wiki/Alice_H._Parker
+"Poindexter, Hildrus",1901,1987,Bacteriologist; epidemiologist,"Work on the epidemiology of tropical diseases, including malaria",NA,https://en.wikipedia.org/wiki/Hildrus_Poindexter
+"Petters, Arlie",1964,NA,Physicist,Work on the mathematical physics of gravitational lensing,NA,https://en.wikipedia.org/wiki/Arlie_Petters
+"Quarterman, Lloyd Albert",1918,1982,Scientist; fluoride chemist,"Manhattan Project, worked with Albert Einstein and Enrico Fermi",NA,https://en.wikipedia.org/wiki/Lloyd_Quarterman
+"Renfroe, Earl",1907,2000,Orthodontist,NA,"126,127,",https://en.wikipedia.org/wiki/Earl_W._Renfroe
+"Rillieux, Norbert",1806,1894,Engineer; inventor,Inventor of the multiple-effect evaporator,"128,",https://en.wikipedia.org/wiki/Norbert_Rillieux
+"Robinson, Larry",1957,NA,Environmental chemist,Investigated possible role of arsenic in the death of Zachary Taylor; interim president of Florida A&M University,NA,https://en.wikipedia.org/wiki/Larry_Robinson_(chemist)
+"Ross, Archia",NA,NA,Inventor,"A runner for stoops (1896), bag closure device (1898), a wrinkle-preventing trouser stretcher (1899), a garment-hanger (1903), and a holder for brooms and like articles.","129,130,131,132,133,",https://en.wikipedia.org/wiki/Archia_Ross
+"Russell, Jesse",1948,NA,Engineer; inventor,Wireless communications engineer,NA,https://en.wikipedia.org/wiki/Jesse_Russell
+"Sammons, Walter",1890,1973,Inventor,Patent for hot comb,"134,",https://en.wikipedia.org/wiki/Thomas_Sowell
+"Steele, Claude",1946,NA,Psychologist; social scientist,Stereotype threat studies,NA,https://en.wikipedia.org/wiki/Claude_Steele
+"Stiff, Lee",1941,NA,Mathematician,President of the National Council of Teachers of Mathematics from 2000 to 2002,"139,",https://en.wikipedia.org/wiki/Lee_Stiff
+"Snyder, Window",1976,NA,Computer engineer,"Security engineer at Microsoft, Mozilla, and Apple",NA,https://en.wikipedia.org/wiki/Window_Snyder
+"Temple, Lewis",1800,1854,Inventor; blacksmith; abolitionist,Inventor of the toggling whaling harpoon head,"140,",https://en.wikipedia.org/wiki/Lewis_Temple
+"Thomas, Vivien",1910,1985,Surgical technician,Blue baby syndrome treatment in the 1940s,"141,142,143,",https://en.wikipedia.org/wiki/Vivien_Thomas
+"Turner, Charles Henry",1867,1923,Zoologist,"First person to prove that insects can hear and can distinguish pitch, that cockroaches can learn by trial and error, and that honeybees can see color; first African-American to receive a PhD from the University of Chicago","144,",https://en.wikipedia.org/wiki/Charles_Henry_Turner_(zoologist)
+"Tyree, G. Bernadette",NA,NA,Biochemist[citation needed],"Program Director, Division of Musculoskeletal Diseases, at National Institute of Arthritis and Musculoskeletal and Skin Diseases, National Institutes of Health","145,",https://en.wikipedia.org/wiki/Neil_deGrasse_Tyson
+"Vaughan, Dorothy",1910,2008,Mathematician,Worked for NACA and NASA at Langley Research Center,NA,https://en.wikipedia.org/wiki/Dorothy_Vaughan
+"Valerino, Powtawche",1980,NA,Engineer,Worked for JPL and NASA at Langley Research Center,NA,https://en.wikipedia.org/wiki/Powtawche_Valerino
+"Walker, Arthur B. C., Jr.",1936,2001,Astronomer,Developed normal incidence multilayer XUV telescopes to photograph the solar corona,"149,150,151,","https://en.wikipedia.org/wiki/Arthur_B._C._Walker,_Jr."
+"Walker, C. J.",1867,1919,Inventor,Created black cosmetic products,"152,",https://en.wikipedia.org/wiki/Madam_C._J._Walker
+"Washington, Warren M.",1936,NA,Atmospheric scientist,Former chair of the National Science Board,"153,154,155,156,",https://en.wikipedia.org/wiki/Warren_M._Washington
+"West, James E.",1931,NA,Acoustician; inventor,Co-developed the foil electret microphone,"157,158,159,",https://en.wikipedia.org/wiki/James_Edward_Maceo_West
+"Wilkins, J. Ernest, Jr.",1923,2011,Mathematician; engineer; nuclear scientist,Entered University of Chicago at age 13; PhD at 19; worked on the Manhattan Project; wrote over 100 scientific papers; helped recruit minorities into the sciences,"160,161,162,","https://en.wikipedia.org/wiki/J._Ernest_Wilkins,_Jr."
+"Williams, Daniel",1856,1931,Surgeon,The first black person on record to have successfully performed pericardium (the sac surrounding the heart) surgery to repair a wound.,"163,circular reference,",https://en.wikipedia.org/wiki/Daniel_Hale_Williams
+"Williams, Scott W.",1943,NA,Mathematician,NA,NA,https://en.wikipedia.org/wiki/Scott_W._Williams
+"Williams, Walter E.",1936,NA,Economist; social scientist,NA,"164,165,166,",https://en.wikipedia.org/wiki/Walter_E._Williams
+"Woods, Granville",1856,1910,Inventor,Invented the synchronous multiplex railway telegraph,"167,",https://en.wikipedia.org/wiki/Granville_Woods
+"Wright, Jane C.",1919,2013,Cancer research and surgeon,Noted for her contributions to chemotherapy and for pioneering the use of the drug methotrexate to treat breast cancer and skin cancer,NA,https://en.wikipedia.org/wiki/Jane_C._Wright
+"Wright, Louis T.",1891,1952,Surgeon,Led team that first used Aureomycin as a treatment on humans,"168,169,170,",https://en.wikipedia.org/wiki/Louis_T._Wright
+"Young, Roger Arliner",1899,1964,Zoologist,First African-American woman to receive a doctorate degree in zoology,"171,172,",https://en.wikipedia.org/wiki/Roger_Arliner_Young


### PR DESCRIPTION
URL for Harold Amos was duplicated (rows 1 & 2) and URL for Roger Arliner Young was missing (row 120).
```
links <- science$links %>% 
  tail(-1) %>% 
  c(., "https://en.wikipedia.org/wiki/Roger_Arliner_Young")

science <- science %>% 
  select(-links) %>% 
  mutate(links = links)

readr::write_csv(science, "science.csv")
```